### PR TITLE
Maven updates and MC 1.13+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,16 @@ mvn clean install
 
 ```
     <repositories>
-        <repository>
-            <id>citizensbooks_repo</id>
-            <url>https://raw.github.com/nicuch/maven_repo/</url>
-        </repository>
+		 <repository>
+		     <id>jitpack.io</id>
+		     <url>https://jitpack.io</url>
+		 </repository>
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>ro.nicuch</groupId>
-            <artifactId>CitizensBooks</artifactId>
-            <version>${latest.version}</version>
-            <scope>provided</scope>
+		     <groupId>com.github.nicuch</groupId>
+		     <artifactId>CitizensBooks</artifactId>
+		     <version>Tag</version>
         </dependency>
     </dependencies>
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ mvn clean install
 	<dependency>
 		<groupId>com.github.nicuch</groupId>
 		<artifactId>CitizensBooks</artifactId>
-		<version>Tag</version>
+		<version>master-SNAPSHOT</version>
 	</dependency>
 </dependencies>
 ```

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ mvn clean install
 ## Maven repository
 
 ```
-	<repositories>
-		<repository>
-			<id>jitpack.io</id>
-			<url>https://jitpack.io</url>
-		</repository>
-	</repositories>
-	<dependencies>
-		<dependency>
-			<groupId>com.github.nicuch</groupId>
-			<artifactId>CitizensBooks</artifactId>
-			<version>Tag</version>
-		</dependency>
-	</dependencies>
+<repositories>
+	<repository>
+		<id>jitpack.io</id>
+		<url>https://jitpack.io</url>
+	</repository>
+</repositories>
+<dependencies>
+	<dependency>
+		<groupId>com.github.nicuch</groupId>
+		<artifactId>CitizensBooks</artifactId>
+		<version>Tag</version>
+	</dependency>
+</dependencies>
 ```

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ mvn clean install
 ## Maven repository
 
 ```
-    <repositories>
-		 <repository>
-		     <id>jitpack.io</id>
-		     <url>https://jitpack.io</url>
-		 </repository>
-    </repositories>
-    <dependencies>
-        <dependency>
-		     <groupId>com.github.nicuch</groupId>
-		     <artifactId>CitizensBooks</artifactId>
-		     <version>Tag</version>
-        </dependency>
-    </dependencies>
+	<repositories>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+	</repositories>
+	<dependencies>
+		<dependency>
+			<groupId>com.github.nicuch</groupId>
+			<artifactId>CitizensBooks</artifactId>
+			<version>Tag</version>
+		</dependency>
+	</dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -4,16 +4,7 @@
     <groupId>ro.nicuch</groupId>
     <artifactId>CitizensBooks</artifactId>
     <version>2.4.7</version>
-    <properties>
-        <github.global.server>github</github.global.server>
-    </properties>
-    <distributionManagement>
-        <repository>
-            <id>internal.repo</id>
-            <name>Temporary Staging Repository</name>
-            <url>file://C:\Workspace\MVN_REPO</url>
-        </repository>
-    </distributionManagement>
+
     <repositories>
         <repository>
             <id>spigot-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,11 @@
             </snapshots>
         </repository>
         <repository>
+             <!-- For Vault -->
+             <id>essx-repo</id>
+             <url>https://ci.ender.zone/plugin/repository/everything/</url>
+        </repository>
+        <repository>
             <id>placeholderapi</id>
             <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>VaultAPI</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/ro/nicuch/citizensbooks/CitizensBooksAPI.java
+++ b/src/main/java/ro/nicuch/citizensbooks/CitizensBooksAPI.java
@@ -20,11 +20,9 @@
 package ro.nicuch.citizensbooks;
 
 import java.lang.reflect.InvocationTargetException;
-import java.math.BigInteger;
 
 import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;

--- a/src/main/java/ro/nicuch/citizensbooks/CitizensCommands.java
+++ b/src/main/java/ro/nicuch/citizensbooks/CitizensCommands.java
@@ -311,7 +311,8 @@ public class CitizensCommands implements TabExecutor {
         sender.sendMessage(ChatColor.GRAY + "" + ChatColor.STRIKETHROUGH + "+----------------------+");
     }
 
-    private boolean hasBookInHand(Player player) {
+    @SuppressWarnings("deprecation")
+	private boolean hasBookInHand(Player player) {
         ItemStack item;
         switch (CitizensBooksAPI.version) {
             case "v1_8_R3":
@@ -332,7 +333,8 @@ public class CitizensCommands implements TabExecutor {
         return (sender instanceof Player);
     }
 
-    private ItemStack getBookFromHand(Player player) {
+    @SuppressWarnings("deprecation")
+	private ItemStack getBookFromHand(Player player) {
         switch (CitizensBooksAPI.version) {
             case "v1_8_R3":
             case "v1_8_R2":
@@ -343,10 +345,15 @@ public class CitizensCommands implements TabExecutor {
         }
     }
 
-    private void openBook(Player player, ItemStack book) {
+    @SuppressWarnings("deprecation")
+	private void openBook(Player player, ItemStack book) {
         BookMeta meta = (BookMeta) book.getItemMeta();
-        ItemStack item = new ItemStack(Material.BOOK_AND_QUILL);
-        item.setItemMeta(meta);
+        ItemStack item = new ItemStack(Material.getMaterial("BOOK_AND_QUILL"));
+		if (item.getType() == null)
+			// 1.13+
+			item.setType(Material.getMaterial("WRITABLE_BOOK"));
+        if (item != null)
+        	item.setItemMeta(meta);
         switch (CitizensBooksAPI.version) {
             case "v1_8_R3":
             case "v1_8_R2":

--- a/src/main/java/ro/nicuch/citizensbooks/PlayerCommands.java
+++ b/src/main/java/ro/nicuch/citizensbooks/PlayerCommands.java
@@ -265,7 +265,8 @@ public class PlayerCommands implements TabExecutor {
         sender.sendMessage(ChatColor.GRAY + "" + ChatColor.STRIKETHROUGH + "+----------------------+");
     }
 
-    private boolean hasBookInHand(Player player) {
+    @SuppressWarnings("deprecation")
+	private boolean hasBookInHand(Player player) {
         ItemStack item;
         switch (CitizensBooksAPI.version) {
             case "v1_8_R3":
@@ -286,7 +287,8 @@ public class PlayerCommands implements TabExecutor {
         return (sender instanceof Player);
     }
 
-    private ItemStack getBookFromHand(Player player) {
+    @SuppressWarnings("deprecation")
+	private ItemStack getBookFromHand(Player player) {
         switch (CitizensBooksAPI.version) {
             case "v1_8_R3":
             case "v1_8_R2":
@@ -297,10 +299,15 @@ public class PlayerCommands implements TabExecutor {
         }
     }
 
-    private void openBook(Player player, ItemStack book) {
+    @SuppressWarnings("deprecation")
+	private void openBook(Player player, ItemStack book) {
         BookMeta meta = (BookMeta) book.getItemMeta();
-        ItemStack item = new ItemStack(Material.BOOK_AND_QUILL);
-        item.setItemMeta(meta);
+        ItemStack item = new ItemStack(Material.getMaterial("BOOK_AND_QUILL"));
+		if (item.getType() == null)
+			// 1.13+
+			item.setType(Material.getMaterial("WRITABLE_BOOK"));
+        if (item != null)
+        	item.setItemMeta(meta);
         switch (CitizensBooksAPI.version) {
             case "v1_8_R3":
             case "v1_8_R2":

--- a/src/main/java/ro/nicuch/citizensbooks/bstats/Metrics.java
+++ b/src/main/java/ro/nicuch/citizensbooks/bstats/Metrics.java
@@ -5,10 +5,8 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.ServicePriority;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
-import ro.nicuch.citizensbooks.CitizensBooksAPI;
 import ro.nicuch.citizensbooks.CitizensBooksPlugin;
 
 import javax.net.ssl.HttpsURLConnection;

--- a/src/main/java/ro/nicuch/citizensbooks/bstats/Metrics.java
+++ b/src/main/java/ro/nicuch/citizensbooks/bstats/Metrics.java
@@ -29,6 +29,7 @@ import java.util.zip.GZIPOutputStream;
  * <p>
  * Check out https://bStats.org/ to learn more about bStats!
  */
+@SuppressWarnings("unchecked")
 public class Metrics {
 
     static {
@@ -154,7 +155,7 @@ public class Metrics {
      *
      * @return The plugin specific data.
      */
-    public JSONObject getPluginData() {
+	public JSONObject getPluginData() {
         JSONObject data = new JSONObject();
 
         if (this.plugin.getSettings().getBoolean("metrics", true)) { //Checking if my plugin will send data


### PR DESCRIPTION
Improvements:

- Fix blunder from #1 where I forgot to include an alternative Vault repo
- Provides instructions for compiling with Jitpack (see [build log](https://jitpack.io/com/github/FlyingPikachu/CitizensBooks/2.4.7/build.log))
- Process materials in a way which will support 1.13+ as well as previous versions
- Add warning suppression for IDEs which complain, like Eclipse